### PR TITLE
CI-685 YCC bundle VM's hangs if shapshot_id doesn't exists

### DIFF
--- a/modules/ycc_vm.py
+++ b/modules/ycc_vm.py
@@ -403,6 +403,8 @@ class YccVM(YC):
                     if "The limit on maximum number of active operations has exceeded" in err._state.details:  # pylint: disable=W0212
                         sleep(5)
                         retry = True
+                    else:
+                        raise err
             else:
                 raise TimeoutError(
                     f"Cloud active operation timeout = {timeout} exceeded"


### PR DESCRIPTION
Fix task hanging when timeout is 0.