### PR TITLE
Fix ycc_vm module bug

### DIFF
--- a/modules/ycc_vm.py
+++ b/modules/ycc_vm.py
@@ -471,12 +471,12 @@ class YccVM(YC):
             ]
         )
 
-        if len(instance["network_interfaces"]) > 1:
+        if len(instance["networkInterfaces"]) > 1:
             err.append("network_interfaces")
         elif spec["assign_internal_ip"] is None:
             pass
         else:
-            if instance["network_interfaces"][0]["primary_v4_address"]["address"] != spec["assign_internal_ip"]:
+            if instance["networkInterfaces"][0]["primaryV4Address"]["address"] != spec["assign_internal_ip"]:
                 err.append("Internal ip addresses are different")
 
         labels = spec["labels"] if spec.get("labels") is not None else {}


### PR DESCRIPTION
Variable instance is return value of MessageToDict function, its "converts" snake case
object properties to camel case dict keys.