### PR TITLE
INFRA-147 Raise error if auth credentials are empty

### DIFF
--- a/module_utils/yc.py
+++ b/module_utils/yc.py
@@ -33,6 +33,10 @@ class YC(AnsibleModule):
         kwargs["argument_spec"] = argument_spec
 
         super().__init__(*args, **kwargs)
+
+        if not (self.params["auth"]["token"] or self.params["auth"]["service_account_key"]):
+            self.fail_json(msg="authorization token or service account key should be provided.")
+
         interceptor = RetryInterceptor(max_retry_count=10)
         if self.params["auth"]["root_certificates"]:
             self.params["auth"]["root_certificates"] = self.params["auth"]["root_certificates"].encode("utf-8")


### PR DESCRIPTION
A check for non empty authorization token or service account key is
added to base module class `__init__`.