### PR TITLE
Implements image_folder paramaneter

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = ansible,google,grpc,yandex,yandexcloud
+known_third_party = ansible,google,grpc,jsonschema,yandex,yandexcloud
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0

--- a/pylintrc
+++ b/pylintrc
@@ -51,7 +51,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 
-disable=missing-docstring,invalid-name,no-self-use,abstract-method,unused-argument,no-else-return,duplicate-code,fixme,no-member,too-few-public-methods,wrong-import-order,redefined-builtin,redefined-outer-name
+disable=missing-docstring,invalid-name,no-self-use,abstract-method,unused-argument,no-else-return,duplicate-code,fixme,no-member,too-few-public-methods,wrong-import-order,redefined-builtin,redefined-outer-name,too-many-lines
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
In order to provide custom images by its family for several folders its
far more convinient to have one folders as image storage, then store a
copy in each folder.

I couldn`t decide what iteration order over "yandex storage", image_folder
and target folder is more convinient so i assume it may be reverted
in order to achive more argumentative result.