### PR TITLE
CST-1092: fixed KeyError.

### DIFF
--- a/modules/ycc_vm.py
+++ b/modules/ycc_vm.py
@@ -510,7 +510,7 @@ class YccVM(YC):
         if str(disk_spec["size"]) != disk["size"]:
             err.append("size")
 
-        if disk_spec.get("image_id") and disk_spec["image_id"] != disk["sourceImageId"]:
+        if disk_spec.get("image_id") and disk.get("sourceImageId") and disk_spec["image_id"] != disk["sourceImageId"]:
             err.append("image_id")
 
         return err


### PR DESCRIPTION
Fixed KeyError: 'sourceImageId' in case of creating VM from deleted snapshot.